### PR TITLE
Build status fix

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -59,6 +59,6 @@ kubectl logs -l step=${BUILDKITE_STEP_ID} --tail=-1 --follow=true
 # debug
 EXIT_CODES=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq '.items[].status.containerStatuses[].state.terminated.exitCode') 
 #echo exit $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
-jq -e $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
+exit $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
 # Set exit code from container status
 #kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq -e ".items[].status.containerStatuses[0].state.terminated.exitCode"

--- a/hooks/command
+++ b/hooks/command
@@ -56,9 +56,5 @@ kubectl wait --for=condition=complete job -l step=${BUILDKITE_STEP_ID} --timeout
 echo "Job logs..."
 kubectl logs -l step=${BUILDKITE_STEP_ID} --tail=-1 --follow=true
 
-# debug
 EXIT_CODES=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq '.items[].status.containerStatuses[].state.terminated.exitCode') 
-#echo exit $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
 exit $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
-# Set exit code from container status
-#kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq -e ".items[].status.containerStatuses[0].state.terminated.exitCode"

--- a/hooks/command
+++ b/hooks/command
@@ -58,7 +58,7 @@ kubectl logs -l step=${BUILDKITE_STEP_ID} --tail=-1 --follow=true
 
 # debug
 EXIT_CODES=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq '.items[].status.containerStatuses[].state.terminated.exitCode') 
-echo exit $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
-
+#echo exit $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
+jq -e $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
 # Set exit code from container status
-kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq -e ".items[].status.containerStatuses[0].state.terminated.exitCode"
+#kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq -e ".items[].status.containerStatuses[0].state.terminated.exitCode"

--- a/hooks/command
+++ b/hooks/command
@@ -58,7 +58,7 @@ kubectl logs -l step=${BUILDKITE_STEP_ID} --tail=-1 --follow=true
 
 # debug
 EXIT_CODES=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq '.items[].status.containerStatuses[].state.terminated.exitCode') 
-echo $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
+echo exit $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
 
 # Set exit code from container status
 kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq -e ".items[].status.containerStatuses[0].state.terminated.exitCode"

--- a/hooks/command
+++ b/hooks/command
@@ -56,5 +56,9 @@ kubectl wait --for=condition=complete job -l step=${BUILDKITE_STEP_ID} --timeout
 echo "Job logs..."
 kubectl logs -l step=${BUILDKITE_STEP_ID} --tail=-1 --follow=true
 
+# debug
+EXIT_CODES=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq '.items[].status.containerStatuses[].state.terminated.exitCode') 
+echo $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
+
 # Set exit code from container status
 kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq -e ".items[].status.containerStatuses[0].state.terminated.exitCode"


### PR DESCRIPTION
This implements a change to the logic that determines the exit statuses of the containers in the plugin pod.  Previously, the exit status of the first container was used, which could cause problems when multiple containers are required.  In the updated logic, the total count of non-zero exit statuses is returned as the pod exit status.