### PR TITLE
Build status logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,5 @@ volumeMounts:
   - name: builds
     mountPath: "/buildkite/builds"
 ```
+
+`timeoutInSeconds` will set how long the job should wait for all of the init containers and containers in the pod spec to finish before reporting an error. Defaults to 300.

--- a/hooks/command
+++ b/hooks/command
@@ -34,7 +34,7 @@ metadata:
     step: ${BUILDKITE_STEP_ID}
 spec:
   backoffLimit: 1
-  completions: 1
+  completions: 0
   parallelism: 1
   ttlSecondsAfterFinished: 600
   template:

--- a/hooks/command
+++ b/hooks/command
@@ -33,7 +33,7 @@ metadata:
     pipeline: ${BUILDKITE_PIPELINE_SLUG}
     step: ${BUILDKITE_STEP_ID}
 spec:
-  backoffLimit: 1
+  backoffLimit: 0
   completions: 1
   parallelism: 1
   ttlSecondsAfterFinished: 600
@@ -43,7 +43,6 @@ spec:
       labels:
         service: buildkite
         pipeline: ${BUILDKITE_PIPELINE_SLUG}
-
         step: ${BUILDKITE_STEP_ID}
     spec: ${POD_SPEC}
 EOF

--- a/hooks/command
+++ b/hooks/command
@@ -34,7 +34,7 @@ metadata:
     step: ${BUILDKITE_STEP_ID}
 spec:
   backoffLimit: 1
-  completions: 0
+  completions: 1
   parallelism: 1
   ttlSecondsAfterFinished: 600
   template:

--- a/hooks/command
+++ b/hooks/command
@@ -56,7 +56,7 @@ echo -e "Found ${INIT_CONTAINER_COUNT} init containers, ${CONTAINER_COUNT} conta
 
 echo "Waiting for job to be complete..."
 TIMEOUT=`expr $(date +%s) + ${TIMEOUT_IN_SECONDS}`
-while [ "$(date +s)" -lt "${TIMEOUT}" ]; do
+while [ "$(date +%s)" -lt "${TIMEOUT}" ]; do
   if kubectl wait --for=condition=complete job -l step=${BUILDKITE_STEP_ID} --timeout=0 2>/dev/null; then
     JOB_RESULT=0
     break

--- a/hooks/command
+++ b/hooks/command
@@ -78,10 +78,10 @@ fi
 echo "Job logs..."
 kubectl logs -l step=${BUILDKITE_STEP_ID} --tail=-1 --follow=true
 
-CONTAINER_STATUSES=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq -cr '[.items[].status.containerStatuses // [], .items[].status.initContainerStatuses // []]| flatten(1)')
-EXIT_CODES=$(jq -cr '.[] | {"name": .name, "exitCode": [.state.terminated.exitCode, .lastState.terminated.exitCode] | max}' <<< "${CONTAINER_STATUSES}")
+CONTAINER_STATUSES=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq -cr '[.items[].status.containerStatuses // [], .items[].status.initContainerStatuses // []] | flatten(1)')
+EXIT_CODES=$(jq -cr 'map({"name": .name, "exitCode": [.state.terminated.exitCode, .lastState.terminated.exitCode] | max})' <<< "${CONTAINER_STATUSES}")
 PP_EXIT_CODES=$(jq -r . <<< "${EXIT_CODES}")
 echo -e "Container exit statuses\n${PP_EXIT_CODES}"
 
 # Exit with the max exitCode
-jq -e '. | max_by(.exitCode)' <<< "${EXIT_CODES}"
+jq -e 'max_by(.exitCode) | .exitCode' <<< "${EXIT_CODES}"

--- a/hooks/command
+++ b/hooks/command
@@ -66,10 +66,11 @@ while [ $(date +s) -lt $TIMEOUT ]; do
     JOB_RESULT=1
     break
   fi
+
   sleep 1
   printf "."
 done
-if [$(date +%s) -ge $TIMEOUT]; then
+if [ $(date +%s) -ge $TIMEOUT ]; then
   echo "Error: Timeout for job expired after ${TIMEOUT_IN_SECONDS} seconds, you can set a longer timeout with the timeoutInSeconds option."
   exit 1
 fi

--- a/hooks/command
+++ b/hooks/command
@@ -53,11 +53,26 @@ TIMEOUT_IN_SECONDS=$(jq -cr '.timeoutInSeconds // 300' <<< "${BUILDKITE_PLUGIN_C
 INIT_CONTAINER_COUNT=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq '.items[].spec.initContainers | length')
 CONTAINER_COUNT=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq '.items[].spec.containers | length')
 echo -e "Found ${INIT_CONTAINER_COUNT} init containers, ${CONTAINER_COUNT} containers"
+
 echo "Waiting for job to be complete..."
-kubectl wait --for=condition=complete job -l step=${BUILDKITE_STEP_ID} --timeout=${TIMEOUT_IN_SECONDS}s || {
+TIMEOUT=`expr $(date +%s) + ${TIMEOUT_IN_SECONDS}`
+while [$(date +s) -lt $TIMEOUT]; do
+  if kubectl wait --for=condition=complete job -l step=${BUILDKITE_STEP_ID} --timeout=0 2>/dev/null; then
+    JOB_RESULT=0
+    break
+  fi
+
+  if kubectl wait --for=condition=failed job -l step=${BUILDKITE_STEP_ID} --timeout=0 2>/dev/null; then
+    JOB_RESULT=1
+    break
+  fi
+  sleep 1
+  printf "."
+done
+if [$(date +%s) -ge $TIMEOUT]; then
   echo "Error: Timeout for job expired after ${TIMEOUT_IN_SECONDS} seconds, you can set a longer timeout with the timeoutInSeconds option."
   exit 1
-}
+fi
 
 echo "Job logs..."
 kubectl logs -l step=${BUILDKITE_STEP_ID} --tail=-1 --follow=true

--- a/hooks/command
+++ b/hooks/command
@@ -33,7 +33,7 @@ metadata:
     pipeline: ${BUILDKITE_PIPELINE_SLUG}
     step: ${BUILDKITE_STEP_ID}
 spec:
-  backoffLimit: 6
+  backoffLimit: 1
   completions: 1
   parallelism: 1
   ttlSecondsAfterFinished: 600

--- a/hooks/command
+++ b/hooks/command
@@ -56,7 +56,7 @@ echo -e "Found ${INIT_CONTAINER_COUNT} init containers, ${CONTAINER_COUNT} conta
 
 echo "Waiting for job to be complete..."
 TIMEOUT=`expr $(date +%s) + ${TIMEOUT_IN_SECONDS}`
-while [$(date +s) -lt $TIMEOUT]; do
+while [ $(date +s) -lt $TIMEOUT ]; do
   if kubectl wait --for=condition=complete job -l step=${BUILDKITE_STEP_ID} --timeout=0 2>/dev/null; then
     JOB_RESULT=0
     break

--- a/hooks/command
+++ b/hooks/command
@@ -59,6 +59,6 @@ kubectl logs -l step=${BUILDKITE_STEP_ID} --tail=-1 --follow=true
 # debug
 EXIT_CODES=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq '.items[].status.containerStatuses[].state.terminated.exitCode') 
 #echo exit $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
-jq -e $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
+exit $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
 # Set exit code from container status
 #kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq -e ".items[].status.containerStatuses[0].state.terminated.exitCode"

--- a/hooks/command
+++ b/hooks/command
@@ -56,9 +56,5 @@ kubectl wait --for=condition=complete job -l step=${BUILDKITE_STEP_ID} --timeout
 echo "Job logs..."
 kubectl logs -l step=${BUILDKITE_STEP_ID} --tail=-1 --follow=true
 
-# debug
 EXIT_CODES=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq '.items[].status.containerStatuses[].state.terminated.exitCode') 
-#echo exit $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
 exit $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
-# Set exit code from container status
-#kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq -e ".items[].status.containerStatuses[0].state.terminated.exitCode"

--- a/hooks/command
+++ b/hooks/command
@@ -79,7 +79,7 @@ echo "Job logs..."
 kubectl logs -l step=${BUILDKITE_STEP_ID} --tail=-1 --follow=true
 
 CONTAINER_STATUSES=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq -cr '[.items[].status.containerStatuses // [], .items[].status.initContainerStatuses // []]| flatten(1)')
-EXIT_CODES=$(jq -cr '{name: .name, exitCode: [.state.terminated.exitCode, .lastState.terminated.exitCode] | max}' <<< "${CONTAINER_STATUSES}")a
+EXIT_CODES=$(jq -cr '.[] | {"name": .name, "exitCode": [.state.terminated.exitCode, .lastState.terminated.exitCode] | max}' <<< "${CONTAINER_STATUSES}")
 PP_EXIT_CODES=$(jq -r . <<< "${EXIT_CODES}")
 echo -e "Container exit statuses\n${PP_EXIT_CODES}"
 

--- a/hooks/command
+++ b/hooks/command
@@ -58,7 +58,7 @@ kubectl logs -l step=${BUILDKITE_STEP_ID} --tail=-1 --follow=true
 
 # debug
 EXIT_CODES=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq '.items[].status.containerStatuses[].state.terminated.exitCode') 
-echo exit $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
-
+#echo exit $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
+jq -e $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
 # Set exit code from container status
-kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq -e ".items[].status.containerStatuses[0].state.terminated.exitCode"
+#kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq -e ".items[].status.containerStatuses[0].state.terminated.exitCode"

--- a/hooks/command
+++ b/hooks/command
@@ -58,7 +58,7 @@ kubectl logs -l step=${BUILDKITE_STEP_ID} --tail=-1 --follow=true
 
 # debug
 EXIT_CODES=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq '.items[].status.containerStatuses[].state.terminated.exitCode') 
-echo $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
+echo exit $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
 
 # Set exit code from container status
 kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq -e ".items[].status.containerStatuses[0].state.terminated.exitCode"

--- a/hooks/command
+++ b/hooks/command
@@ -84,6 +84,4 @@ PP_EXIT_CODES=$(jq -r . <<< "${EXIT_CODES}")
 echo -e "Container exit statuses\n${PP_EXIT_CODES}"
 
 # Exit with the max exitCode
-BUILD_EXIT_CODE=$(jq -cr 'max_by(.exitCode) | .exitCode' <<< "${EXIT_CODES}")
-echo "Build exit code=$BUILD_EXIT_CODE"
-exit $BUILD_EXIT_CODE
+jq -e 'max_by(.exitCode) | .exitCode == 0' <<< "${EXIT_CODES}"

--- a/hooks/command
+++ b/hooks/command
@@ -56,7 +56,7 @@ echo -e "Found ${INIT_CONTAINER_COUNT} init containers, ${CONTAINER_COUNT} conta
 
 echo "Waiting for job to be complete..."
 TIMEOUT=`expr $(date +%s) + ${TIMEOUT_IN_SECONDS}`
-while [ $(date +s) -lt $TIMEOUT ]; do
+while [ "$(date +s)" -lt "${TIMEOUT}" ]; do
   if kubectl wait --for=condition=complete job -l step=${BUILDKITE_STEP_ID} --timeout=0 2>/dev/null; then
     JOB_RESULT=0
     break
@@ -70,7 +70,7 @@ while [ $(date +s) -lt $TIMEOUT ]; do
   sleep 1
   printf "."
 done
-if [ $(date +%s) -ge $TIMEOUT ]; then
+if [ "$(date +%s)" -ge "${TIMEOUT}" ]; then
   echo "Error: Timeout for job expired after ${TIMEOUT_IN_SECONDS} seconds, you can set a longer timeout with the timeoutInSeconds option."
   exit 1
 fi

--- a/hooks/command
+++ b/hooks/command
@@ -78,10 +78,10 @@ fi
 echo "Job logs..."
 kubectl logs -l step=${BUILDKITE_STEP_ID} --tail=-1 --follow=true
 
-CONTAINER_STATUSES=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | '[.items[].status.containerStatuses // [], .items[].status.initContainerStatuses // []]| flatten(1)')
+CONTAINER_STATUSES=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq -cr '[.items[].status.containerStatuses // [], .items[].status.initContainerStatuses // []]| flatten(1)')
 EXIT_CODES=$(jq -cr '{name: .name, exitCode: [.state.terminated.exitCode, .lastState.terminated.exitCode] | max}' <<< "${CONTAINER_STATUSES}")a
 PP_EXIT_CODES=$(jq -r . <<< "${EXIT_CODES}")
 echo -e "Container exit statuses\n${PP_EXIT_CODES}"
 
 # Exit with the max exitCode
-jq -e '. | max_by(.exitCode)' <<< "${EXIT_CODES}
+jq -e '. | max_by(.exitCode)' <<< "${EXIT_CODES}"

--- a/hooks/command
+++ b/hooks/command
@@ -84,4 +84,6 @@ PP_EXIT_CODES=$(jq -r . <<< "${EXIT_CODES}")
 echo -e "Container exit statuses\n${PP_EXIT_CODES}"
 
 # Exit with the max exitCode
-jq -e 'max_by(.exitCode) | .exitCode' <<< "${EXIT_CODES}"
+BUILD_EXIT_CODE=$(jq -cr 'max_by(.exitCode) | .exitCode' <<< "${EXIT_CODES}")
+echo "Build exit code=$BUILD_EXIT_CODE"
+exit $BUILD_EXIT_CODE

--- a/hooks/command
+++ b/hooks/command
@@ -56,5 +56,9 @@ kubectl wait --for=condition=complete job -l step=${BUILDKITE_STEP_ID} --timeout
 echo "Job logs..."
 kubectl logs -l step=${BUILDKITE_STEP_ID} --tail=-1 --follow=true
 
+# debug
+EXIT_CODES=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq '.items[].status.containerStatuses[].state.terminated.exitCode') 
+echo $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
+
 # Set exit code from container status
 kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq -e ".items[].status.containerStatuses[0].state.terminated.exitCode"

--- a/hooks/command
+++ b/hooks/command
@@ -50,11 +50,23 @@ EOF
 
 echo -e "Using annotations\n${PP_ANNOTATIONS}"
 
+TIMEOUT_IN_SECONDS=$(jq -cr '.timeoutInSeconds // 300' <<< "${BUILDKITE_PLUGIN_CONFIGURATION}")
+INIT_CONTAINER_COUNT=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq '.items[].spec.initContainers | length')
+CONTAINER_COUNT=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq '.items[].spec.containers | length')
+echo -e "Found ${INIT_CONTAINER_COUNT} init containers, ${CONTAINER_COUNT} containers"
 echo "Waiting for job to be complete..."
-kubectl wait --for=condition=complete job -l step=${BUILDKITE_STEP_ID} --timeout=60s || true
+kubectl wait --for=condition=complete job -l step=${BUILDKITE_STEP_ID} --timeout=${TIMEOUT_IN_SECONDS}s || {
+  echo "Error: Timeout for job expired after ${TIMEOUT_IN_SECONDS} seconds, you can set a longer timeout with the timeoutInSeconds option."
+  exit 1
+}
 
 echo "Job logs..."
 kubectl logs -l step=${BUILDKITE_STEP_ID} --tail=-1 --follow=true
 
-EXIT_CODES=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | jq '.items[].status.containerStatuses[].state.terminated.exitCode') 
-exit $(expr $(wc -l <<< "$EXIT_CODES") - $(grep 0 <<< "$EXIT_CODES" | wc -l))
+CONTAINER_STATUSES=$(kubectl get -l step=${BUILDKITE_STEP_ID} pod -o json | '[.items[].status.containerStatuses // [], .items[].status.initContainerStatuses // []]| flatten(1)')
+EXIT_CODES=$(jq -cr '{name: .name, exitCode: [.state.terminated.exitCode, .lastState.terminated.exitCode] | max}' <<< "${CONTAINER_STATUSES}")a
+PP_EXIT_CODES=$(jq -r . <<< "${EXIT_CODES}")
+echo -e "Container exit statuses\n${PP_EXIT_CODES}"
+
+# Exit with the max exitCode
+jq -e '. | max_by(.exitCode)' <<< "${EXIT_CODES}

--- a/plugin.yml
+++ b/plugin.yml
@@ -18,6 +18,8 @@ configuration:
       type: boolean
     mount-source:
       type: boolean
+    timeoutInSeconds:
+      type: number
   required:
     - pod-spec
   additionalProperties: false


### PR DESCRIPTION
### Changelog
- Add check for lastState exit codes for pods with retries
- Add timeoutInSeconds option to wait on job longer
- Add logging for exit codes by container name
- Add initContainer exit codes
- Rewrite wait logic to wait for the job to succeed or fail

### Additional logging
```
...
Found 0 init containers, 2 containers
...
Container exit statuses
[
  {
    "name": "dd-78-01840e0b-7fb9-415a-a06b-f1549ba54d74-failure",
    "exitCode": 1
  },
  {
    "name": "dd-78-01840e0b-7fb9-415a-a06b-f1549ba54d74-success",
    "exitCode": 0
  }
]
```